### PR TITLE
add store to the code snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,8 @@ import counterReducer from "./features/counter/counterSlice.js";
 import App from "./App";
 import "./index.css";
 
+const store = createStore(counterReducer);
+
 // code change - added Provider to wrap around App
 ReactDOM.render(
   <Provider store={store}>


### PR DESCRIPTION
In the first code snippet there is `const store = createStore(counterReducer);` but in the second code snippet, it has been removed and used `store` directly. So I thought this can make some confusion and it might be better to add this line back to the second code snippet as well.